### PR TITLE
refactor: move some pydantic models around

### DIFF
--- a/stapi-fastapi/src/stapi_fastapi/__init__.py
+++ b/stapi-fastapi/src/stapi_fastapi/__init__.py
@@ -1,18 +1,6 @@
-from .models import (
-    Link,
-    OpportunityProperties,
-    Product,
-    Provider,
-    ProviderRole,
-)
 from .routers import ProductRouter, RootRouter
 
 __all__ = [
-    "Link",
-    "OpportunityProperties",
-    "Product",
     "ProductRouter",
-    "Provider",
-    "ProviderRole",
     "RootRouter",
 ]

--- a/stapi-fastapi/src/stapi_fastapi/backends/product_backend.py
+++ b/stapi-fastapi/src/stapi_fastapi/backends/product_backend.py
@@ -6,13 +6,14 @@ from typing import Any
 from fastapi import Request
 from returns.maybe import Maybe
 from returns.result import ResultE
-from stapi_pydantic.opportunity import (
+from stapi_pydantic import (
     Opportunity,
     OpportunityCollection,
     OpportunityPayload,
     OpportunitySearchRecord,
+    Order,
+    OrderPayload,
 )
-from stapi_pydantic.order import Order, OrderPayload
 
 from stapi_fastapi.routers.product_router import ProductRouter
 

--- a/stapi-fastapi/src/stapi_fastapi/backends/root_backend.py
+++ b/stapi-fastapi/src/stapi_fastapi/backends/root_backend.py
@@ -4,8 +4,8 @@ from typing import Any, TypeVar
 from fastapi import Request
 from returns.maybe import Maybe
 from returns.result import ResultE
-from stapi_pydantic.opportunity import OpportunitySearchRecord
-from stapi_pydantic.order import (
+from stapi_pydantic import (
+    OpportunitySearchRecord,
     Order,
     OrderStatus,
 )

--- a/stapi-fastapi/src/stapi_fastapi/conformance.py
+++ b/stapi-fastapi/src/stapi_fastapi/conformance.py
@@ -1,0 +1,3 @@
+CORE = "https://stapi.example.com/v0.1.0/core"
+OPPORTUNITIES = "https://stapi.example.com/v0.1.0/opportunities"
+ASYNC_OPPORTUNITIES = "https://stapi.example.com/v0.1.0/async-opportunities"

--- a/stapi-fastapi/src/stapi_fastapi/models/__init__.py
+++ b/stapi-fastapi/src/stapi_fastapi/models/__init__.py
@@ -1,13 +1,3 @@
-from stapi_pydantic.opportunity import OpportunityProperties
-from stapi_pydantic.product import Provider, ProviderRole
-from stapi_pydantic.shared import Link
-
 from .product import Product
 
-__all__ = [
-    "Link",
-    "OpportunityProperties",
-    "Product",
-    "Provider",
-    "ProviderRole",
-]
+__all__ = ["Product"]

--- a/stapi-fastapi/src/stapi_fastapi/models/product.py
+++ b/stapi-fastapi/src/stapi_fastapi/models/product.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from stapi_pydantic.product import Product as BaseProduct
+from stapi_pydantic import Product as BaseProduct
 
 if TYPE_CHECKING:
     from stapi_fastapi.backends.product_backend import (

--- a/stapi-fastapi/src/stapi_fastapi/models/root.py
+++ b/stapi-fastapi/src/stapi_fastapi/models/root.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from stapi_pydantic.shared import Link
+from stapi_pydantic import Link
 
 
 class RootResponse(BaseModel):

--- a/stapi-fastapi/src/stapi_fastapi/routers/product_router.py
+++ b/stapi-fastapi/src/stapi_fastapi/routers/product_router.py
@@ -17,15 +17,17 @@ from fastapi.responses import JSONResponse
 from geojson_pydantic.geometries import Geometry
 from returns.maybe import Maybe, Some
 from returns.result import Failure, Success
-from stapi_pydantic.json_schema_model import JsonSchemaModel
-from stapi_pydantic.opportunity import (
+from stapi_pydantic import (
+    JsonSchemaModel,
+    Link,
     OpportunityCollection,
     OpportunityPayload,
     OpportunitySearchRecord,
+    Order,
+    OrderPayload,
+    OrderStatus,
     Prefer,
 )
-from stapi_pydantic.order import Order, OrderPayload, OrderStatus
-from stapi_pydantic.shared import Link
 
 from stapi_fastapi.constants import TYPE_JSON
 from stapi_fastapi.exceptions import ConstraintsException, NotFoundException

--- a/stapi-fastapi/src/stapi_fastapi/routers/root_router.py
+++ b/stapi-fastapi/src/stapi_fastapi/routers/root_router.py
@@ -6,23 +6,18 @@ from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.datastructures import URL
 from returns.maybe import Maybe, Some
 from returns.result import Failure, Success
-from stapi_pydantic.conformance import (
-    ASYNC_OPPORTUNITIES,
-    CORE,
+from stapi_pydantic import (
     Conformance,
-)
-from stapi_pydantic.opportunity import (
+    Link,
     OpportunitySearchRecord,
     OpportunitySearchRecords,
-)
-from stapi_pydantic.order import (
     Order,
     OrderCollection,
     OrderStatus,
     OrderStatuses,
+    ProductsCollection,
+    RootResponse,
 )
-from stapi_pydantic.product import ProductsCollection
-from stapi_pydantic.shared import Link
 
 from stapi_fastapi.backends.root_backend import (
     GetOpportunitySearchRecord,
@@ -31,10 +26,10 @@ from stapi_fastapi.backends.root_backend import (
     GetOrders,
     GetOrderStatuses,
 )
+from stapi_fastapi.conformance import ASYNC_OPPORTUNITIES, CORE
 from stapi_fastapi.constants import TYPE_GEOJSON, TYPE_JSON
 from stapi_fastapi.exceptions import NotFoundException
 from stapi_fastapi.models.product import Product
-from stapi_fastapi.models.root import RootResponse
 from stapi_fastapi.responses import GeoJSONResponse
 from stapi_fastapi.routers.product_router import ProductRouter
 from stapi_fastapi.routers.route_names import (

--- a/stapi-fastapi/tests/application.py
+++ b/stapi-fastapi/tests/application.py
@@ -8,8 +8,8 @@ from fastapi import FastAPI
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from stapi_fastapi.conformance import CORE, OPPORTUNITIES
 from stapi_fastapi.routers.root_router import RootRouter
-from stapi_pydantic.conformance import CORE, OPPORTUNITIES
 
 from tests.backends import (
     mock_get_opportunity_search_record,

--- a/stapi-fastapi/tests/backends.py
+++ b/stapi-fastapi/tests/backends.py
@@ -5,15 +5,13 @@ from fastapi import Request
 from returns.maybe import Maybe, Nothing, Some
 from returns.result import Failure, ResultE, Success
 from stapi_fastapi.routers.product_router import ProductRouter
-from stapi_pydantic.opportunity import (
+from stapi_pydantic import (
     Opportunity,
     OpportunityCollection,
     OpportunityPayload,
     OpportunitySearchRecord,
     OpportunitySearchStatus,
     OpportunitySearchStatusCode,
-)
-from stapi_pydantic.order import (
     Order,
     OrderPayload,
     OrderProperties,

--- a/stapi-fastapi/tests/conftest.py
+++ b/stapi-fastapi/tests/conftest.py
@@ -7,12 +7,12 @@ from urllib.parse import urljoin
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from stapi_fastapi.conformance import ASYNC_OPPORTUNITIES, CORE, OPPORTUNITIES
 from stapi_fastapi.models.product import (
     Product,
 )
 from stapi_fastapi.routers.root_router import RootRouter
-from stapi_pydantic.conformance import ASYNC_OPPORTUNITIES, CORE, OPPORTUNITIES
-from stapi_pydantic.opportunity import (
+from stapi_pydantic import (
     Opportunity,
 )
 

--- a/stapi-fastapi/tests/shared.py
+++ b/stapi-fastapi/tests/shared.py
@@ -13,18 +13,17 @@ from httpx import Response
 from pydantic import BaseModel, Field, model_validator
 from pytest import fail
 from stapi_fastapi.models.product import Product
-from stapi_pydantic.opportunity import (
+from stapi_pydantic import (
     Opportunity,
     OpportunityCollection,
     OpportunityProperties,
     OpportunitySearchRecord,
-)
-from stapi_pydantic.order import (
     Order,
     OrderParameters,
     OrderStatus,
+    Provider,
+    ProviderRole,
 )
-from stapi_pydantic.product import Provider, ProviderRole
 
 from .backends import (
     mock_create_order,

--- a/stapi-fastapi/tests/test_conformance.py
+++ b/stapi-fastapi/tests/test_conformance.py
@@ -1,6 +1,6 @@
 from fastapi import status
 from fastapi.testclient import TestClient
-from stapi_pydantic.conformance import CORE
+from stapi_fastapi.conformance import CORE
 
 
 def test_conformance(stapi_client: TestClient) -> None:

--- a/stapi-fastapi/tests/test_datetime_interval.py
+++ b/stapi-fastapi/tests/test_datetime_interval.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 from pydantic import BaseModel, ValidationError
 from pyrfc3339.utils import format_timezone
 from pytest import mark, raises
-from stapi_pydantic.datetime_interval import DatetimeInterval
+from stapi_pydantic import DatetimeInterval
 
 EUROPE_BERLIN = ZoneInfo("Europe/Berlin")
 

--- a/stapi-fastapi/tests/test_opportunity.py
+++ b/stapi-fastapi/tests/test_opportunity.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-from stapi_pydantic.opportunity import (
+from stapi_pydantic import (
     OpportunityCollection,
 )
 

--- a/stapi-fastapi/tests/test_opportunity_async.py
+++ b/stapi-fastapi/tests/test_opportunity_async.py
@@ -6,13 +6,13 @@ from uuid import uuid4
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
-from stapi_pydantic.opportunity import (
+from stapi_pydantic import (
+    Link,
     OpportunityCollection,
     OpportunitySearchRecord,
     OpportunitySearchStatus,
     OpportunitySearchStatusCode,
 )
-from stapi_pydantic.shared import Link
 
 from .shared import (
     create_mock_opportunity,

--- a/stapi-fastapi/tests/test_order.py
+++ b/stapi-fastapi/tests/test_order.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from geojson_pydantic import Point
 from geojson_pydantic.types import Position2D
 from httpx import Response
-from stapi_pydantic.order import Order, OrderPayload, OrderStatus, OrderStatusCode
+from stapi_pydantic import Order, OrderPayload, OrderStatus, OrderStatusCode
 
 from .shared import MyOrderParameters, find_link, pagination_tester
 

--- a/stapi-fastapi/tests/test_root.py
+++ b/stapi-fastapi/tests/test_root.py
@@ -1,6 +1,6 @@
 from fastapi import status
 from fastapi.testclient import TestClient
-from stapi_pydantic.conformance import CORE
+from stapi_fastapi.conformance import CORE
 
 
 def test_root(stapi_client: TestClient, assert_link) -> None:

--- a/stapi-pydantic/CHANGELOG.md
+++ b/stapi-pydantic/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Added some more models from **stapi-fastapi**, removed conformance urls ([#51](https://github.com/stapi-spec/pystapi/pull/51))
+
 ## [0.0.1] - 2025-04-01
 
 Initial release.

--- a/stapi-pydantic/CHANGELOG.md
+++ b/stapi-pydantic/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Added some more models from **stapi-fastapi**, removed conformance urls ([#51](https://github.com/stapi-spec/pystapi/pull/51))
+- Added more top-level imports, removed conformance urls ([#51](https://github.com/stapi-spec/pystapi/pull/51))
 
 ## [0.0.1] - 2025-04-01
 

--- a/stapi-pydantic/src/stapi_pydantic/__init__.py
+++ b/stapi-pydantic/src/stapi_pydantic/__init__.py
@@ -1,3 +1,6 @@
+from .conformance import Conformance
+from .datetime_interval import DatetimeInterval
+from .json_schema_model import JsonSchemaModel
 from .opportunity import (
     Opportunity,
     OpportunityCollection,
@@ -7,11 +10,27 @@ from .opportunity import (
     OpportunitySearchRecords,
     OpportunitySearchStatus,
     OpportunitySearchStatusCode,
+    Prefer,
+)
+from .order import (
+    Order,
+    OrderCollection,
+    OrderParameters,
+    OrderPayload,
+    OrderProperties,
+    OrderSearchParameters,
+    OrderStatus,
+    OrderStatusCode,
+    OrderStatuses,
 )
 from .product import Product, ProductsCollection, Provider, ProviderRole
+from .root import RootResponse
 from .shared import Link
 
 __all__ = [
+    "Conformance",
+    "DatetimeInterval",
+    "JsonSchemaModel",
     "Link",
     "Opportunity",
     "OpportunityCollection",
@@ -21,8 +40,19 @@ __all__ = [
     "OpportunitySearchRecords",
     "OpportunitySearchStatus",
     "OpportunitySearchStatusCode",
+    "Order",
+    "OrderCollection",
+    "OrderParameters",
+    "OrderPayload",
+    "OrderProperties",
+    "OrderSearchParameters",
+    "OrderStatus",
+    "OrderStatusCode",
+    "OrderStatuses",
+    "Prefer",
     "Product",
     "ProductsCollection",
     "Provider",
     "ProviderRole",
+    "RootResponse",
 ]

--- a/stapi-pydantic/src/stapi_pydantic/conformance.py
+++ b/stapi-pydantic/src/stapi_pydantic/conformance.py
@@ -1,9 +1,5 @@
 from pydantic import BaseModel, Field
 
-CORE = "https://stapi.example.com/v0.1.0/core"
-OPPORTUNITIES = "https://stapi.example.com/v0.1.0/opportunities"
-ASYNC_OPPORTUNITIES = "https://stapi.example.com/v0.1.0/async-opportunities"
-
 
 class Conformance(BaseModel):
     conforms_to: list[str] = Field(default_factory=list, serialization_alias="conformsTo")


### PR DESCRIPTION
## What I'm changing

- Move some more **pydantic** models down into **stapi-pydantic** 
- Move conformance uris back up into **stapi-fastapi**
- Change all `stapi_pydantic` imports to take directly from the top-level (simpler, IMO)

## Checklist

- [x] Tests pass: `uv run pytest`
- [x] Checks pass: `uv run pre-commit --all-files`
- [x] CHANGELOG is updated (if necessary)
