### PR TITLE
Update & fix validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,8 @@ filterwarnings = [
     "error",
     "ignore:The 'app' shortcut is now deprecated.:DeprecationWarning",
     "ignore:Pydantic serializer warnings:UserWarning",
-    "ignore:jsonschema.RefResolver is deprecated as of v4.18.0:DeprecationWarning",
+    "default:jsonschema.exceptions.RefResolutionError is deprecated:DeprecationWarning",
+    "default:jsonschema.RefResolver is deprecated as of v4.18.0:DeprecationWarning",
 ]
 markers = [
     "mock_products",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ filterwarnings = [
     "error",
     "ignore:The 'app' shortcut is now deprecated.:DeprecationWarning",
     "ignore:Pydantic serializer warnings:UserWarning",
-    "ignore:jsonschema.exceptions.RefResolutionError is deprecated:DeprecationWarning",
+    "ignore:jsonschema.RefResolver is deprecated as of v4.18.0:DeprecationWarning",
 ]
 markers = [
     "mock_products",

--- a/pystapi-validator/pyproject.toml
+++ b/pystapi-validator/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "schemathesis>=3.37.0",
+    "schemathesis>=3.39.14",
     "pytest>=8.3.3",
     "requests>=2.32.3",
     "pyyaml>=6.0.2",

--- a/pystapi-validator/tests/validate_api.py
+++ b/pystapi-validator/tests/validate_api.py
@@ -2,14 +2,6 @@ import json
 
 import pytest
 import schemathesis
-from schemathesis.checks import (
-    content_type_conformance,
-    negative_data_rejection,
-    not_a_server_error,
-    response_headers_conformance,
-    response_schema_conformance,
-    status_code_conformance,
-)
 
 schemathesis.experimental.OPEN_API_3_1.enable()
 
@@ -21,19 +13,11 @@ BASE_URL = "http://localhost:8000"
 
 @schema.parametrize()
 def test_api(case):
-    response = case.call_and_validate(base_url=BASE_URL)
-    case.validate_response(response)
-
-    not_a_server_error(response, case)
-    status_code_conformance(response, case)
-    content_type_conformance(response, case)
-    response_schema_conformance(response, case)
-    response_headers_conformance(response, case)
-    negative_data_rejection(response, case)
+    case.call_and_validate(base_url=BASE_URL)
 
 
 def test_openapi_specification():
-    assert schema.validate()
+    schema.validate()
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1296,7 +1296,7 @@ requires-dist = [
     { name = "pytest-metadata", specifier = ">=3.1.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
-    { name = "schemathesis", specifier = ">=3.37.0" },
+    { name = "schemathesis", specifier = ">=3.39.14" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What I'm changing

- Updating Schemathesis version
- Fixed usage
  - call_and_validate actually runs all tests internally
  - validate raises on error instead of returning a result
- Warn but do not fail on deprecation warnings from inside Schemathesis

Currently the validator is detecting two errors

1. Undocumented Content-Type       
           Received: application/geo+json
           Documented: application/json
       
2. Response violates schema
          'orders' is a required property (see https://github.com/stapi-spec/stapi-spec/pull/265)

## Checklist

- [X] Tests pass: `uv run pytest`
- [X] Checks pass: `uv run pre-commit --all-files`
- [ ] CHANGELOG is updated (if necessary)
