### PR TITLE
refactor: opinionated tweaks to pystapi-client tests

### DIFF
--- a/pystapi-client/tests/conftest.py
+++ b/pystapi-client/tests/conftest.py
@@ -1,37 +1,35 @@
 import json
-from collections.abc import Generator
+from collections.abc import Iterator
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
-import httpx
 import pytest
 import respx
-from httpx import Response
+from httpx import Request, Response
+from respx import MockRouter
 
 WORKING_DIR = Path(__file__).parent
 
 
 def load_fixture(name: str) -> dict[str, Any]:
     with open(WORKING_DIR / "fixtures" / f"{name}.json") as f:
-        return json.load(f)  # type: ignore[no-any-return]
+        return cast(dict, json.load(f))
 
 
 @pytest.fixture
-def mocked_api() -> Generator[respx.MockRouter, None, None]:
+def api() -> Iterator[MockRouter]:
     landing_page_data = load_fixture("landing_page")
     products = load_fixture("products")
 
-    with respx.mock(base_url="https://stapi.example.com", assert_all_called=False) as respx_mock:
+    with respx.mock(base_url="http://stapi.test", assert_all_called=False) as respx_mock:
         landing_page = respx_mock.get("/")
         landing_page.return_value = Response(200, json=landing_page_data)
 
         conformance_route = respx_mock.get("/conformance")
         conformance_route.return_value = Response(200, json={"conformsTo": landing_page_data["conformsTo"]})
 
-        # products_route.return_value = Response(200, json=products)
-
-        def mock_products_response(request: httpx.Request) -> httpx.Response:
+        def mock_products_response(request: Request) -> Response:
             products_limited = deepcopy(products)
             limit = request.url.params.get("limit")
             page = int(request.url.params.get("page", 1))
@@ -43,7 +41,7 @@ def mocked_api() -> Generator[respx.MockRouter, None, None]:
                 if has_next_page:
                     products_limited["links"].append(
                         {
-                            "href": "https://stapi.example.com/products?limit=1&page=2",
+                            "href": "http://stapi.test/products?limit=1&page=2",
                             "method": "GET",
                             "rel": "next",
                         }

--- a/pystapi-client/tests/fixtures/landing_page.json
+++ b/pystapi-client/tests/fixtures/landing_page.json
@@ -1,9 +1,8 @@
-
 {
     "id": "example-stapi",
     "title": "A simple STAPI Example",
     "description": "This API demonstrated the landing page for a SpatioTemporal Asset Tasking API",
-    "conformsTo" : [
+    "conformsTo": [
         "https://stapi.example.com/v0.1.0/core",
         "https://geojson.org/schema/Point.json",
         "https://geojson.org/schema/Polygon.json"
@@ -12,34 +11,32 @@
         {
             "rel": "conformance",
             "type": "application/json",
-            "href": "https://stapi.example.com/conformance",
+            "href": "http://stapi.test/conformance",
             "title": "Conformance classes implemented by this API"
         },
         {
             "rel": "orders",
             "type": "application/json",
-            "href": "https://stapi.example.com/orders",
+            "href": "http://stapi.test/orders",
             "title": "List of existing orders"
         },
         {
             "rel": "products",
             "type": "application/json",
-            "href": "https://stapi.example.com/products",
+            "href": "http://stapi.test/products",
             "title": "List of available products"
         },
         {
             "rel": "service-desc",
             "type": "application/vnd.oai.openapi+json;version=3.0",
-            "href": "https://stapi.example.com/api",
+            "href": "http://stapi.test/api",
             "title": "The machine-readable API definition"
-
         },
         {
             "rel": "service-doc",
             "type": "text/html",
-            "href": "https://stapi.example.com/api.html",
+            "href": "http://stapi.test/api.html",
             "title": "The human-readable API documentation"
-
         }
     ]
 }

--- a/pystapi-client/tests/fixtures/products.json
+++ b/pystapi-client/tests/fixtures/products.json
@@ -22,7 +22,7 @@
             ],
             "links": [
                 {
-                    "href": "https://stapi.example.com/",
+                    "href": "http://stapi.test/",
                     "rel": "latest-version",
                     "type": "media type",
                     "title": "title"
@@ -123,7 +123,7 @@
             ],
             "links": [
                 {
-                    "href": "https://stapi.example.com/",
+                    "href": "http://stapi.test/",
                     "rel": "latest-version",
                     "type": "media type",
                     "title": "title"

--- a/pystapi-client/tests/test_client.py
+++ b/pystapi-client/tests/test_client.py
@@ -1,25 +1,25 @@
-import respx
 from pystapi_client.client import Client
+from respx import MockRouter
 from stapi_pydantic import Link
 
 
-def test_get_products(mocked_api: respx.MockRouter) -> None:
-    client = Client.open(url="https://stapi.example.com")
+def test_get_products(api: MockRouter) -> None:
+    client = Client.open(url="http://stapi.test")
 
     products = list(client.get_products())
     assert len(products) == 2
 
 
-def test_get_products_paginated(mocked_api: respx.MockRouter) -> None:
-    client = Client.open(url="https://stapi.example.com")
+def test_get_products_paginated(api: MockRouter) -> None:
+    client = Client.open(url="http://stapi.test")
 
     products = list(client.get_products(limit=1))
     assert len(products) == 2
 
 
-def test_pagination(mocked_api: respx.MockRouter) -> None:
-    client = Client.open(url="https://stapi.example.com")
+def test_pagination(api: MockRouter) -> None:
+    client = Client.open(url="http://stapi.test")
 
-    products_link = Link(href="https://stapi.example.com/products", method="GET", body={"limit": 1}, rel="")
+    products_link = Link(href="http://stapi.test/products", method="GET", body={"limit": 1}, rel="")
     for products_collection in client.stapi_io.get_pages(products_link, "products"):
         assert len(products_collection["products"]) == 1


### PR DESCRIPTION
## What I'm changing

- Tweak some import styles to @gadomski's preference (classes imported directly)
- Rename `mocked_api` to `api` since it's unlikely we'll ever have a real API in the test suite
- Use `http://stapi.test` instead of `https://stapi.example.com` (@gadomski prefers [.test](https://en.wikipedia.org/wiki/.test) to make it clear that urls are for a test case ... `example.com` actually resolves to something, wheras `.test` never will)

## Checklist

- [x] Tests pass: `uv run pytest`
- [x] Checks pass: `uv run pre-commit --all-files`
