### PR TITLE
prep stapi-fastapi release v0.7.0

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,14 +3,15 @@
 1. Determine which package you're releasing
 2. Determine the next version, following [semantic versioning](https://semver.org/)
 3. Create a release branch: `git checkout -b release/{package}-v{version}`
-4. Update that package's CHANGELOG with:
+4. Update that package's `pyproject.toml` with the new version
+5. Update that package's CHANGELOG with:
    - A new header with the new version
    - A new link at the bottom of the CHANGELOG for that header
-5. `git push -u origin`
-6. Once approved, merge the PR
-7. `git checkout main && git pull && scripts/release {package}`
-8. Go to the draft release href provided by the script, update that Github release with information from the CHANGELOG, and publish it
-9. Github actions will automatically publish a new PyPI release
+6. `git push -u origin`
+7. Once approved, merge the PR
+8. `git checkout main && git pull && scripts/release {package}`
+9. Go to the draft release href provided by the script, update that Github release with information from the CHANGELOG, and publish it
+10. Github actions will automatically publish a new PyPI release
 
 > [!IMPORTANT]
 > You'll need to set up [.netrc authentication](https://pygithub.readthedocs.io/en/stable/examples/Authentication.html#netrc-authentication) to use `scripts/release`.

--- a/stapi-fastapi/CHANGELOG.md
+++ b/stapi-fastapi/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+## [0.7.0] - 2025-04-18
+
 ### Fixed
 
 - Add parameter method as "POST" to create-order link
@@ -120,6 +122,7 @@ Initial release
 - Add links `opportunities` and `create-order` to Product
 - Add link `create-order` to OpportunityCollection
 
+[0.7.0]: https://github.com/stapi-spec/stapi-fastapi/tree/v0.7.0
 [0.6.0]: https://github.com/stapi-spec/stapi-fastapi/tree/v0.6.0
 [0.5.0]: https://github.com/stapi-spec/stapi-fastapi/tree/v0.5.0
 [0.4.0]: https://github.com/stapi-spec/stapi-fastapi/tree/v0.4.0

--- a/stapi-fastapi/pyproject.toml
+++ b/stapi-fastapi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stapi-fastapi"
-version = "0.6.0"
+version = "0.7.0"
 description = "Sensor Tasking API (STAPI) with FastAPI"
 authors = [
     { name = "Christian Wygoda", email = "christian.wygoda@wygoda.net" },

--- a/uv.lock
+++ b/uv.lock
@@ -2112,7 +2112,7 @@ wheels = [
 
 [[package]]
 name = "stapi-fastapi"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "stapi-fastapi" }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What I'm changing

- Update stapi-fastapi CHANGELOG to prep v0.7.0 release

## How I did it

- n/a

## Checklist

- [X] Tests pass: `uv run pytest`
- [X] Checks pass: `uv run pre-commit run --all-files`
- [X] CHANGELOG is updated (if necessary)
