### PR TITLE
stapi-pydantic release prep 0.0.3

### DIFF
--- a/stapi-pydantic/CHANGELOG.md
+++ b/stapi-pydantic/CHANGELOG.md
@@ -1,10 +1,11 @@
+<!-- markdownlint-disable MD024 -->
 # Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.3] - 2025-04-24
 
 ### Added
 
@@ -26,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Initial release.
 
-[unreleased]: https://github.com/stapi-spec/pystapi/compare/stac-pydantic/stapi-pydantic%2Fv0.0.2...main
+<!-- [unreleased]: https://github.com/stapi-spec/pystapi/compare/stac-pydantic/stapi-pydantic%2Fv0.0.2...main -->
+[0.0.3]: https://github.com/stapi-spec/pystapi/compare/stac-pydantic/stapi-pydantic%2Fv0.0.2...stapi-pydantic%2Fv0.0.3
 [0.0.2]: https://github.com/stapi-spec/pystapi/compare/stac-pydantic/stapi-pydantic%2Fv0.0.1...stapi-pydantic%2Fv0.0.2
 [0.0.1]: https://github.com/stapi-spec/pystapi/releases/tag/stapi-pydantic%2Fv0.0.1

--- a/stapi-pydantic/pyproject.toml
+++ b/stapi-pydantic/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "stapi-pydantic"
-version = "0.0.2"
+version = "0.0.3"
 description = "Pydantic models for Satellite Tasking API (STAPI) Specification"
 readme = "README.md"
 authors = [
-    { name = "Phil Varner", email = "phil@philvarner.com" },
+    { name = "Phil Varner", email = "philvarner@gmail.com" },
     { name = "Pete Gadomski", email = "pete.gadomski@gmail.com" },
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION
## What I'm changing

- update version to 0.0.3 for a release in pyproject.toml and changelog

## How I did it

n/a

## Checklist

- [X] Tests pass: `uv run pytest`
- [X] Checks pass: `uv run pre-commit run --all-files`
- [X] CHANGELOG is updated (if necessary)
