### PR TITLE
add stapi-pydantic to the stapi-fastapi dependencies

### DIFF
--- a/stapi-fastapi/CHANGELOG.md
+++ b/stapi-fastapi/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+### Fixed
+
+- Add stapi-pydantic as a dependency
+
 ## [0.7.0] - 2025-04-18
 
 ### Fixed

--- a/stapi-fastapi/pyproject.toml
+++ b/stapi-fastapi/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pyrfc3339>=1.1",
     "types-pyRFC3339>=1.1.1",
     "uvicorn>=0.29.0",
+    "stapi-pydantic>=0.0.3",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/uv.lock
+++ b/uv.lock
@@ -2124,6 +2124,7 @@ dependencies = [
     { name = "pygeofilter" },
     { name = "pyrfc3339" },
     { name = "returns" },
+    { name = "stapi-pydantic" },
     { name = "types-pyrfc3339" },
     { name = "uvicorn" },
 ]
@@ -2139,13 +2140,14 @@ requires-dist = [
     { name = "pygeofilter", specifier = ">=0.2" },
     { name = "pyrfc3339", specifier = ">=1.1" },
     { name = "returns", specifier = ">=0.23" },
+    { name = "stapi-pydantic", editable = "stapi-pydantic" },
     { name = "types-pyrfc3339", specifier = ">=1.1.1" },
     { name = "uvicorn", specifier = ">=0.29.0" },
 ]
 
 [[package]]
 name = "stapi-pydantic"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "stapi-pydantic" }
 dependencies = [
     { name = "cql2" },


### PR DESCRIPTION
## What I'm changing

- stapi-fastapi depends on stapi-pydantic, but it was not in the dependencies list

- https://github.com/stapi-spec/pystapi/issues/104
- https://github.com/stapi-spec/pystapi/issues/103

## How I did it

- added to dependencies list

## Checklist

- [X] Tests pass: `uv run pytest`
- [X] Checks pass: `uv run pre-commit run --all-files`
- [X] CHANGELOG is updated (if necessary)
