### PR TITLE
release stapi-fastapi 0.7.1 with stapi-pydantic dependency

### DIFF
--- a/stapi-fastapi/CHANGELOG.md
+++ b/stapi-fastapi/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.7.1] - 2025-04-25
 
 ### Fixed
 
@@ -126,6 +126,7 @@ Initial release
 - Add links `opportunities` and `create-order` to Product
 - Add link `create-order` to OpportunityCollection
 
+[0.7.1]: https://github.com/stapi-spec/stapi-fastapi/tree/v0.7.1
 [0.7.0]: https://github.com/stapi-spec/stapi-fastapi/tree/v0.7.0
 [0.6.0]: https://github.com/stapi-spec/stapi-fastapi/tree/v0.6.0
 [0.5.0]: https://github.com/stapi-spec/stapi-fastapi/tree/v0.5.0

--- a/stapi-fastapi/pyproject.toml
+++ b/stapi-fastapi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stapi-fastapi"
-version = "0.7.0"
+version = "0.7.1"
 description = "Sensor Tasking API (STAPI) with FastAPI"
 authors = [
     { name = "Christian Wygoda", email = "christian.wygoda@wygoda.net" },

--- a/uv.lock
+++ b/uv.lock
@@ -2112,7 +2112,7 @@ wheels = [
 
 [[package]]
 name = "stapi-fastapi"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "stapi-fastapi" }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What I'm changing

- release stapi-fastapi 0.7.1

## How I did it

n/a

## Checklist

- [x] Tests pass: `uv run pytest`
- [x] Checks pass: `uv run pre-commit run --all-files`
- [x] CHANGELOG is updated (if necessary)
