### PR TITLE
fix: json schema for datetime

### DIFF
--- a/stapi-pydantic/src/stapi_pydantic/datetime_interval.py
+++ b/stapi-pydantic/src/stapi_pydantic/datetime_interval.py
@@ -39,5 +39,5 @@ DatetimeInterval = Annotated[
     BeforeValidator(validate_before),
     AfterValidator(validate_after),
     WrapSerializer(serialize, return_type=str),
-    WithJsonSchema({"type": "string"}, mode="serialization"),
+    WithJsonSchema({"type": "string"}),
 ]

--- a/stapi-pydantic/src/stapi_pydantic/order.py
+++ b/stapi-pydantic/src/stapi_pydantic/order.py
@@ -129,7 +129,7 @@ class OrderCollection(_GeoJsonBase, Generic[T]):
 
 
 class OrderPayload(BaseModel, Generic[ORP]):
-    datetime: DatetimeInterval
+    datetime: DatetimeInterval = Field(examples=["2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"])
     geometry: Geometry
     # TODO: validate the CQL2 filter?
     filter: CQL2Filter | None = None  # type: ignore [type-arg]

--- a/stapi-pydantic/tests/test_json_schema.py
+++ b/stapi-pydantic/tests/test_json_schema.py
@@ -1,0 +1,6 @@
+from pydantic import TypeAdapter
+from stapi_pydantic.datetime_interval import DatetimeInterval
+
+
+def test_datetime_interval() -> None:
+    assert TypeAdapter(DatetimeInterval).json_schema() == {"type": "string"}


### PR DESCRIPTION
## What I'm changing

- Use `{"type": "string"}` for the OpenAPI docs for datetime, too

## How I did it

- Also added an example
