### PR TITLE
refactor method url_for in ProductRouter and RootRouter

### DIFF
--- a/stapi-fastapi/src/stapi_fastapi/routers/product_router.py
+++ b/stapi-fastapi/src/stapi_fastapi/routers/product_router.py
@@ -199,50 +199,34 @@ class ProductRouter(APIRouter):
                 tags=["Products"],
             )
 
+    @staticmethod
+    def url_for(request: Request, name: str, /, **path_params: Any) -> str:
+        return str(request.url_for(name, **path_params))
+
     def get_product(self, request: Request) -> ProductPydantic:
         links = [
             Link(
-                href=str(
-                    request.url_for(
-                        f"{self.root_router.name}:{self.product.id}:{GET_PRODUCT}",
-                    ),
-                ),
+                href=self.url_for(request, f"{self.root_router.name}:{self.product.id}:{GET_PRODUCT}"),
                 rel="self",
                 type=TYPE_JSON,
             ),
             Link(
-                href=str(
-                    request.url_for(
-                        f"{self.root_router.name}:{self.product.id}:{CONFORMANCE}",
-                    ),
-                ),
+                href=self.url_for(request, f"{self.root_router.name}:{self.product.id}:{CONFORMANCE}"),
                 rel="conformance",
                 type=TYPE_JSON,
             ),
             Link(
-                href=str(
-                    request.url_for(
-                        f"{self.root_router.name}:{self.product.id}:{GET_QUERYABLES}",
-                    ),
-                ),
+                href=self.url_for(request, f"{self.root_router.name}:{self.product.id}:{GET_QUERYABLES}"),
                 rel="queryables",
                 type=TYPE_JSON,
             ),
             Link(
-                href=str(
-                    request.url_for(
-                        f"{self.root_router.name}:{self.product.id}:{GET_ORDER_PARAMETERS}",
-                    ),
-                ),
+                href=self.url_for(request, f"{self.root_router.name}:{self.product.id}:{GET_ORDER_PARAMETERS}"),
                 rel="order-parameters",
                 type=TYPE_JSON,
             ),
             Link(
-                href=str(
-                    request.url_for(
-                        f"{self.root_router.name}:{self.product.id}:{CREATE_ORDER}",
-                    ),
-                ),
+                href=self.url_for(request, f"{self.root_router.name}:{self.product.id}:{CREATE_ORDER}"),
                 rel="create-order",
                 type=TYPE_JSON,
                 method="POST",
@@ -254,11 +238,7 @@ class ProductRouter(APIRouter):
         ):
             links.append(
                 Link(
-                    href=str(
-                        request.url_for(
-                            f"{self.root_router.name}:{self.product.id}:{SEARCH_OPPORTUNITIES}",
-                        ),
-                    ),
+                    href=self.url_for(request, f"{self.root_router.name}:{self.product.id}:{SEARCH_OPPORTUNITIES}"),
                     rel="opportunities",
                     type=TYPE_JSON,
                 ),
@@ -420,11 +400,7 @@ class ProductRouter(APIRouter):
 
     def order_link(self, request: Request, opp_req: OpportunityPayload) -> Link:
         return Link(
-            href=str(
-                request.url_for(
-                    f"{self.root_router.name}:{self.product.id}:{CREATE_ORDER}",
-                ),
-            ),
+            href=self.url_for(request, f"{self.root_router.name}:{self.product.id}:{CREATE_ORDER}"),
             rel="create-order",
             type=TYPE_JSON,
             method="POST",
@@ -456,11 +432,10 @@ class ProductRouter(APIRouter):
             case Success(Some(opportunity_collection)):
                 opportunity_collection.links.append(
                     Link(
-                        href=str(
-                            request.url_for(
-                                f"{self.root_router.name}:{self.product.id}:{GET_OPPORTUNITY_COLLECTION}",
-                                opportunity_collection_id=opportunity_collection_id,
-                            ),
+                        href=self.url_for(
+                            request,
+                            f"{self.root_router.name}:{self.product.id}:{GET_OPPORTUNITY_COLLECTION}",
+                            opportunity_collection_id=opportunity_collection_id,
                         ),
                         rel="self",
                         type=TYPE_JSON,

--- a/stapi-fastapi/src/stapi_fastapi/routers/root_router.py
+++ b/stapi-fastapi/src/stapi_fastapi/routers/root_router.py
@@ -171,35 +171,39 @@ class RootRouter(APIRouter):
 
         self.conformances = list(_conformances)
 
+    @staticmethod
+    def url_for(request: Request, name: str, /, **path_params: Any) -> str:
+        return str(request.url_for(name, **path_params))
+
     def get_root(self, request: Request) -> RootResponse:
         links = [
             Link(
-                href=str(request.url_for(f"{self.name}:{ROOT}")),
+                href=self.url_for(request, f"{self.name}:{ROOT}"),
                 rel="self",
                 type=TYPE_JSON,
             ),
             Link(
-                href=str(request.url_for(self.openapi_endpoint_name)),
+                href=self.url_for(request, self.openapi_endpoint_name),
                 rel="service-description",
                 type=TYPE_JSON,
             ),
             Link(
-                href=str(request.url_for(self.docs_endpoint_name)),
+                href=self.url_for(request, self.docs_endpoint_name),
                 rel="service-docs",
                 type="text/html",
             ),
             Link(
-                href=str(request.url_for(f"{self.name}:{CONFORMANCE}")),
+                href=self.url_for(request, f"{self.name}:{CONFORMANCE}"),
                 rel="conformance",
                 type=TYPE_JSON,
             ),
             Link(
-                href=str(request.url_for(f"{self.name}:{LIST_PRODUCTS}")),
+                href=self.url_for(request, f"{self.name}:{LIST_PRODUCTS}"),
                 rel="products",
                 type=TYPE_JSON,
             ),
             Link(
-                href=str(request.url_for(f"{self.name}:{LIST_ORDERS}")),
+                href=self.url_for(request, f"{self.name}:{LIST_ORDERS}"),
                 rel="orders",
                 type=TYPE_GEOJSON,
             ),
@@ -208,7 +212,7 @@ class RootRouter(APIRouter):
         if self.supports_async_opportunity_search:
             links.append(
                 Link(
-                    href=str(request.url_for(f"{self.name}:{LIST_OPPORTUNITY_SEARCH_RECORDS}")),
+                    href=self.url_for(request, f"{self.name}:{LIST_OPPORTUNITY_SEARCH_RECORDS}"),
                     rel="opportunity-search-records",
                     type=TYPE_JSON,
                 ),
@@ -236,7 +240,7 @@ class RootRouter(APIRouter):
         ids = self.product_ids[start:end]
         links = [
             Link(
-                href=str(request.url_for(f"{self.name}:{LIST_PRODUCTS}")),
+                href=self.url_for(request, f"{self.name}:{LIST_PRODUCTS}"),
                 rel="self",
                 type=TYPE_JSON,
             ),

--- a/stapi-fastapi/src/stapi_fastapi/routers/root_router.py
+++ b/stapi-fastapi/src/stapi_fastapi/routers/root_router.py
@@ -3,7 +3,6 @@ import traceback
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, status
-from fastapi.datastructures import URL
 from returns.maybe import Maybe, Some
 from returns.result import Failure, Success
 from stapi_pydantic import (
@@ -343,21 +342,21 @@ class RootRouter(APIRouter):
         self.product_routers[product.id] = product_router
         self.product_ids = [*self.product_routers.keys()]
 
-    def generate_order_href(self, request: Request, order_id: str) -> URL:
-        return request.url_for(f"{self.name}:{GET_ORDER}", order_id=order_id)
+    def generate_order_href(self, request: Request, order_id: str) -> str:
+        return self.url_for(request, f"{self.name}:{GET_ORDER}", order_id=order_id)
 
-    def generate_order_statuses_href(self, request: Request, order_id: str) -> URL:
-        return request.url_for(f"{self.name}:{LIST_ORDER_STATUSES}", order_id=order_id)
+    def generate_order_statuses_href(self, request: Request, order_id: str) -> str:
+        return self.url_for(request, f"{self.name}:{LIST_ORDER_STATUSES}", order_id=order_id)
 
     def order_links(self, order: Order[OrderStatus], request: Request) -> list[Link]:
         return [
             Link(
-                href=str(self.generate_order_href(request, order.id)),
+                href=self.generate_order_href(request, order.id),
                 rel="self",
                 type=TYPE_GEOJSON,
             ),
             Link(
-                href=str(self.generate_order_statuses_href(request, order.id)),
+                href=self.generate_order_statuses_href(request, order.id),
                 rel="monitor",
                 type=TYPE_JSON,
             ),
@@ -365,11 +364,10 @@ class RootRouter(APIRouter):
 
     def order_statuses_link(self, request: Request, order_id: str) -> Link:
         return Link(
-            href=str(
-                request.url_for(
-                    f"{self.name}:{LIST_ORDER_STATUSES}",
-                    order_id=order_id,
-                )
+            href=self.url_for(
+                request,
+                f"{self.name}:{LIST_ORDER_STATUSES}",
+                order_id=order_id,
             ),
             rel="self",
             type=TYPE_JSON,
@@ -457,8 +455,9 @@ class RootRouter(APIRouter):
             case _:
                 raise AssertionError("Expected code to be unreachable")
 
-    def generate_opportunity_search_record_href(self, request: Request, search_record_id: str) -> URL:
-        return request.url_for(
+    def generate_opportunity_search_record_href(self, request: Request, search_record_id: str) -> str:
+        return self.url_for(
+            request,
             f"{self.name}:{GET_OPPORTUNITY_SEARCH_RECORD}",
             search_record_id=search_record_id,
         )
@@ -467,7 +466,7 @@ class RootRouter(APIRouter):
         self, opportunity_search_record: OpportunitySearchRecord, request: Request
     ) -> Link:
         return Link(
-            href=str(self.generate_opportunity_search_record_href(request, opportunity_search_record.id)),
+            href=self.generate_opportunity_search_record_href(request, opportunity_search_record.id),
             rel="self",
             type=TYPE_JSON,
         )

--- a/stapi-pydantic/CHANGELOG.md
+++ b/stapi-pydantic/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- ProductRouter and RootRouter now have a method `url_for` that makes the link generation code slightly cleaner and
+  allows for overridding in child classes, to support proxy rewrite of the links.
+
 ## [0.0.4] - 2025-07-17
 
 ### Added


### PR DESCRIPTION
## What I'm changing

- refactor use of Request#url_for into a static method in RootRouter and ProductRouter

## How I did it

I created a new static method that all of the generated links use.

The intention of this is to allow child class implementations for projects that use this library to override this if they want to change the urls. A key use case for this is when the API is being proxied from another API, and there is the desire for the links to be correct wrt the URLs provided by the reverse proxy.

## Checklist

- [X] Tests pass: `uv run pytest`
- [X] Checks pass: `uv run pre-commit run --all-files`
- [X] CHANGELOG is updated (if necessary)
