### PR TITLE
Optional order datetime geometry

### DIFF
--- a/stapi-pydantic/CHANGELOG.md
+++ b/stapi-pydantic/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- `OrderPayload` changed so that the `geometry` and `datetime` fields are optional. This is in support of ordering non-tasked imagery (i.e. already collected imagery) where `geometry` and `datetime` are not necessary to fulfill the order. 
+- `OrderPayload` changed so that the `geometry` and `datetime` fields are optional. This is in support of ordering non-tasked imagery (i.e. already collected imagery) where `geometry` and `datetime` are not necessary to fulfill the order.
 
 ### Added
 

--- a/stapi-pydantic/CHANGELOG.md
+++ b/stapi-pydantic/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `OrderPayload` changed so that the `geometry` and `datetime` fields are optional. This is in support of ordering non-tasked imagery (i.e. already collected imagery) where `geometry` and `datetime` are not necessary to fulfill the order. 
+
 ### Added
 
 - ProductRouter and RootRouter now have a method `url_for` that makes the link generation code slightly cleaner and

--- a/stapi-pydantic/src/stapi_pydantic/order.py
+++ b/stapi-pydantic/src/stapi_pydantic/order.py
@@ -144,8 +144,8 @@ class OrderCollection(_GeoJsonBase, Generic[T]):
 
 
 class OrderPayload(BaseModel, Generic[ORP]):
-    datetime: DatetimeInterval = Field(examples=["2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"])
-    geometry: Geometry
+    datetime: DatetimeInterval | None = Field(examples=["2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"], default=None)
+    geometry: Geometry | None = None
     # TODO: validate the CQL2 filter?
     filter: CQL2Filter | None = None  # type: ignore [type-arg]
 


### PR DESCRIPTION
## What I'm changing

- Making `datetime` and `geometry` optional in `OrderPayload` for cases where they are not required. This is aimed at ordering archival imagery where a filter or order parameter is sufficient to fulfill the order without requiring spatiotemporal constraints.

## How I did it

- Made `None` an option for the two fields.

## Checklist

- [x ] Tests pass: `uv run pytest`
- [ x] Checks pass: `uv run pre-commit run --all-files`
- [x ] CHANGELOG is updated (if necessary)
